### PR TITLE
ln - fixed "Apply to be a Rider" in NavBar and fixed ROLE_RIDER granted authority

### DIFF
--- a/frontend/src/fixtures/currentUserFixtures.js
+++ b/frontend/src/fixtures/currentUserFixtures.js
@@ -365,6 +365,19 @@ const currentUserFixtures = {
             ]
         },
     },
+    riderMember: {
+        loggedIn: true,
+        root: {
+            ...(apiCurrentUserFixtures.riderOnly),
+            rolesList: [
+                "SCOPE_openid",
+                "ROLE_RIDER",
+                "ROLE_MEMBER",
+                "SCOPE_https://www.googleapis.com/auth/userinfo.profile",
+                "SCOPE_https://www.googleapis.com/auth/userinfo.email",
+            ]
+        },
+    },
     memberOnly: {
         loggedIn: true,
         root: {

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                !hasRole(currentUser, "ROLE_RIDER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && hasRole(currentUser, "ROLE_MEMBER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,7 +115,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 )
               }
               {
-                hasRole(currentUser, "ROLE_MEMBER") && (
+                !hasRole(currentUser, "ROLE_RIDER") && (
                   <Nav.Link as={Link} to="/apply/rider">Apply to be a Rider</Nav.Link>
                 )
               }

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -634,7 +634,9 @@ describe("AppNavbar tests", () => {
 
         await waitFor(() => expect(getByText("Welcome, Phill Conrad")).toBeInTheDocument());
         const chatMenu = getByTestId("appnavbar-chat-dropdown");
-        expect(chatMenu).toBeInTheDocument();        
+        expect(chatMenu).toBeInTheDocument();    
+        const applyMenu = screen.queryByText("Apply to be a Rider");
+        expect(applyMenu).toBeInTheDocument();      
     });
 
 
@@ -653,7 +655,9 @@ describe("AppNavbar tests", () => {
 
         await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
         const chatMenu = screen.queryByTestId("appnavbar-chat-dropdown");
-        expect(chatMenu).not.toBeInTheDocument();        
+        expect(chatMenu).not.toBeInTheDocument();  
+        const applyRiderMenu = screen.queryByText("Apply to be a Rider");
+        expect(applyRiderMenu).not.toBeInTheDocument();        
     });
 
     test("Driver page link should not appear for a user that is not a participant", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -681,5 +681,23 @@ describe("AppNavbar tests", () => {
         expect(applyMenu).not.toBeInTheDocument();      
     });
 
+    test("Apply to be a Rider should only appear for a user that is not a rider and is a member", async () => {
+        const currentUser = currentUserFixtures.riderMember;
+        const doLogin = jest.fn();
+
+        const { getByText } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByText("Welcome, Phillip Conrad")).toBeInTheDocument());
+        const applyMenu = screen.queryByText("Apply to be a Rider");
+        expect(applyMenu).not.toBeInTheDocument();
+    });
+
+
 });
 

--- a/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
+++ b/src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java
@@ -48,13 +48,18 @@ public class RoleInterceptor implements HandlerInterceptor {
                 Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
                 Set<GrantedAuthority> revisedAuthorities = authorities.stream().filter(
                         grantedAuth -> !grantedAuth.getAuthority().equals("ROLE_ADMIN")
-                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER"))
+                                && !grantedAuth.getAuthority().equals("ROLE_DRIVER")
+                                && !grantedAuth.getAuthority().equals(
+                                        "ROLE_RIDER"))
                         .collect(Collectors.toSet());
                 if (user.getAdmin()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 }
                 if (user.getDriver()) {
                     revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                }
+                if (user.getRider()) {
+                    revisedAuthorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 }
                 Authentication newAuth = new OAuth2AuthenticationToken(principal, revisedAuthorities,
                         (((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId()));

--- a/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
+++ b/src/test/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptorTests.java
@@ -62,6 +62,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                 Set<GrantedAuthority> authorities = new HashSet<>();
                 authorities.add(new SimpleGrantedAuthority("ROLE_ADMIN"));
                 authorities.add(new SimpleGrantedAuthority("ROLE_DRIVER"));
+                authorities.add(new SimpleGrantedAuthority("ROLE_RIDER"));
                 authorities.add(new SimpleGrantedAuthority("ROLE_MEMBER"));
 
                 OAuth2User user = new DefaultOAuth2User(authorities, attributes, "name");
@@ -94,6 +95,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .id(15L)
                                 .admin(false)
                                 .driver(true)
+                                .rider(false)
                                 .build();
                 when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
 
@@ -120,10 +122,13 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertFalse(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertTrue(role_driver, "ROLE_DRIVER should be in roles list");
+                assertFalse(role_rider, "ROLE_RIDER shouldn't be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 
@@ -134,6 +139,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .id(15L)
                                 .admin(true)
                                 .driver(false)
+                                .rider(true)
                                 .build();
                 when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
 
@@ -160,10 +166,57 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
-                assertFalse(role_driver, "ROLE_DRIVER should be in roles list");
+                assertFalse(role_driver, "ROLE_DRIVER shouldn't be in roles list");
+                assertTrue(role_rider, "ROLE_RIDER should be in roles list");
+                assertTrue(role_member, "ROLE_MEMBER should be in roles list");
+        }
+
+        @Test
+        public void updates_rider_role_when_user_rider_false() throws Exception {
+                User user = User.builder()
+                                .email("cgaucho@ucsb.edu")
+                                .id(15L)
+                                .admin(true)
+                                .driver(false)
+                                .rider(false)
+                                .build();
+                when(userRepository.findByEmail("cgaucho@ucsb.edu")).thenReturn(Optional.of(user));
+
+                MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/currentUser");
+                HandlerExecutionChain chain = mapping.getHandler(request);
+                MockHttpServletResponse response = new MockHttpServletResponse();
+
+                assert chain != null;
+                Optional<HandlerInterceptor> RoleInterceptor = chain.getInterceptorList()
+                                .stream()
+                                .filter(RoleInterceptor.class::isInstance)
+                                .findFirst();
+
+                assertTrue(RoleInterceptor.isPresent());
+
+                RoleInterceptor.get().preHandle(request, response, chain.getHandler());
+
+                verify(userRepository, times(1)).findByEmail("cgaucho@ucsb.edu");
+
+                Collection<? extends GrantedAuthority> authorities = SecurityContextHolder.getContext()
+                                .getAuthentication().getAuthorities();
+
+                boolean role_admin = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
+                boolean role_driver = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
+                boolean role_member = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
+                assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
+                assertFalse(role_driver, "ROLE_DRIVER shouldn't be in roles list");
+                assertFalse(role_rider, "ROLE_RIDER shouldn't be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 
@@ -174,6 +227,7 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .id(15L)
                                 .admin(false)
                                 .driver(false)
+                                .rider(false)
                                 .build();
                 when(userRepository.findByEmail("cgaucho2@ucsb.edu")).thenReturn(Optional.of(user));
 
@@ -200,10 +254,13 @@ public class RoleInterceptorTests extends ControllerTestCase {
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_ADMIN"));
                 boolean role_driver = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_DRIVER"));
+                boolean role_rider = authorities.stream()
+                                .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_RIDER"));
                 boolean role_member = authorities.stream()
                                 .anyMatch(grantedAuth -> grantedAuth.getAuthority().equals("ROLE_MEMBER"));
                 assertTrue(role_admin, "ROLE_ADMIN should not be in roles list");
                 assertTrue(role_driver, "ROLE_DRIVER should be in roles list");
+                assertTrue(role_rider, "ROLE_RIDER should be in roles list");
                 assertTrue(role_member, "ROLE_MEMBER should be in roles list");
         }
 }


### PR DESCRIPTION
"Apply to be a Rider" in the Navbar now only shows if user does NOT have ROLE_RIDER. 

The ROLE_RIDER was not being granted or taken away when toggled by Admin. This was fixed by adding ROLE_RIDER to RoleInterceptor.java. 

Files changed: 
frontend/src/main/components/Nav/AppNavbar.js
src/main/java/edu/ucsb/cs156/gauchoride/interceptors/RoleInterceptor.java

Closes #25