### PR TITLE
Andy field names hover (optional part from issue #94)

### DIFF
--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -20,14 +20,23 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
    
     const testIdPrefix = "RideForm";
 
-    const [isHovered, setIsHovered] = useState(false);
+    const [isHovered1, setIsHovered1] = useState(false);
+    const [isHovered2, setIsHovered2] = useState(false);
 
-    const handleMouseEnter = () => {
-        setIsHovered(true);
+    const handleMouseEnter1 = () => {
+        setIsHovered1(true);
     };
 
-    const handleMouseLeave = () => {
-        setIsHovered(false);
+    const handleMouseLeave1 = () => {
+        setIsHovered1(false);
+    };
+
+    const handleMouseEnter2 = () => {
+        setIsHovered2(true);
+    };
+
+    const handleMouseLeave2 = () => {
+        setIsHovered2(false);
     };
 
     return (
@@ -77,7 +86,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="start">Pick Up Time</Form.Label>
                 <Form.Control
-                    onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}
+                    onMouseEnter={handleMouseEnter1} onMouseLeave={handleMouseLeave1}
                     data-testid={testIdPrefix + "-start"}
                     id="start"
                     type="text"
@@ -97,7 +106,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     {errors.start?.message}
                 </Form.Control.Feedback>
 
-                {isHovered && (
+                {isHovered1 && (
                     <div
                         style={
                             {
@@ -107,7 +116,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                                 background: 'rgba(240,240,240,1)',
                                 padding: '5px',
                                 zIndex: '999',
-                                borderRadius: '6px'
+                                borderRadius: '6px',
                             }
                         }> This is when you would like to be picked up </div>
                 )}
@@ -118,7 +127,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
             <Form.Group className="mb-3">
                 <Form.Label htmlFor="end" >Drop Off Time</Form.Label>
                 <Form.Control
-                    onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}
+                    onMouseEnter={handleMouseEnter2} onMouseLeave={handleMouseLeave2}
                     data-testid={testIdPrefix + "-end"}
                     id="end"
                     type="text"
@@ -137,7 +146,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                     {errors.end?.message}
                 </Form.Control.Feedback>
 
-                {isHovered && (
+                {isHovered2 && (
                     <div
                         style={
                             {

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Button, Form } from 'react-bootstrap';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
@@ -19,6 +20,15 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
    
     const testIdPrefix = "RideForm";
 
+    const [isHovered, setIsHovered] = useState(false);
+
+    const handleMouseEnter = () => {
+        setIsHovered(true);
+    };
+
+    const handleMouseLeave = () => {
+        setIsHovered(false);
+    };
 
     return (
 
@@ -64,7 +74,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className="mb-3" >
+            <Form.Group className="mb-3" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
                 <Form.Label htmlFor="start">Pick Up Time</Form.Label>
                 <Form.Control
                     data-testid={testIdPrefix + "-start"}
@@ -85,7 +95,20 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Form.Control.Feedback type="invalid">
                     {errors.start?.message}
                 </Form.Control.Feedback>
+
+                {isHovered && (
+                    <div
+                        style={
+                            {
+                                position: 'absolute',
+                                top: '100%',
+                                left: '30px'
+                            }
+                        }> Hello World </div>
+                )}
+
             </Form.Group>
+
 
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="end">Drop Off Time</Form.Label>

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -118,7 +118,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                                 zIndex: '999',
                                 borderRadius: '6px',
                             }
-                        }> This is when you would like to be picked up </div>
+                        }>This is when you would like to be picked up</div>
                 )}
 
             </Form.Group>
@@ -158,7 +158,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                                 zIndex: '999',
                                 borderRadius: '6px'
                             }
-                        }> This is the latest you would like to arrive by </div>
+                        }>This is the latest you would like to arrive by</div>
                 )}
 
             </Form.Group>

--- a/frontend/src/main/components/Ride/RideForm.js
+++ b/frontend/src/main/components/Ride/RideForm.js
@@ -74,9 +74,10 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 </Form.Control.Feedback>
             </Form.Group>
 
-            <Form.Group className="mb-3" onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
+            <Form.Group className="mb-3">
                 <Form.Label htmlFor="start">Pick Up Time</Form.Label>
                 <Form.Control
+                    onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}
                     data-testid={testIdPrefix + "-start"}
                     id="start"
                     type="text"
@@ -101,18 +102,23 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                         style={
                             {
                                 position: 'absolute',
-                                top: '100%',
-                                left: '30px'
+                                left: '500px',
+                                top: '264px',
+                                background: 'rgba(240,240,240,1)',
+                                padding: '5px',
+                                zIndex: '999',
+                                borderRadius: '6px'
                             }
-                        }> Hello World </div>
+                        }> This is when you would like to be picked up </div>
                 )}
 
             </Form.Group>
 
 
-            <Form.Group className="mb-3" >
-                <Form.Label htmlFor="end">Drop Off Time</Form.Label>
+            <Form.Group className="mb-3">
+                <Form.Label htmlFor="end" >Drop Off Time</Form.Label>
                 <Form.Control
+                    onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}
                     data-testid={testIdPrefix + "-end"}
                     id="end"
                     type="text"
@@ -130,6 +136,22 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Form.Control.Feedback type="invalid">
                     {errors.end?.message}
                 </Form.Control.Feedback>
+
+                {isHovered && (
+                    <div
+                        style={
+                            {
+                                position: 'absolute',
+                                left: '500px',
+                                top: '350px',
+                                background: 'rgba(240,240,240,1)',
+                                padding: '5px',
+                                zIndex: '999',
+                                borderRadius: '6px'
+                            }
+                        }> This is the latest you would like to arrive by </div>
+                )}
+
             </Form.Group>
             
             <Form.Group className="mb-3" >
@@ -148,6 +170,7 @@ function RideForm({ initialContents, submitAction, buttonLabel = "Create" }) {
                 <Form.Control.Feedback type="invalid">
                     {errors.pickupBuilding?.message}
                 </Form.Control.Feedback>
+
             </Form.Group>
 
             <Form.Group className="mb-3" >

--- a/frontend/src/tests/components/Ride/RideForm.test.js
+++ b/frontend/src/tests/components/Ride/RideForm.test.js
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
+import '@testing-library/jest-dom';
 import { rideFixtures } from "fixtures/rideFixtures";
 import RideForm from "main/components/Ride/RideForm";
-
 import { QueryClient, QueryClientProvider } from "react-query";
 
 const mockedNavigate = jest.fn();
@@ -72,6 +72,32 @@ describe("RideForm tests", () => {
         fireEvent.click(cancelButton);
 
         await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+    });
+
+
+    test('pick up time description appears after hover delay', async () => {
+        render(<RideForm />);
+      
+        const pickUpTimeField = screen.getByTestId('RideForm-start');
+        fireEvent.mouseEnter(pickUpTimeField);
+      
+        expect(await screen.findByText('This is when you would like to be picked up')).toBeInTheDocument();
+
+        fireEvent.mouseLeave(pickUpTimeField);
+        expect(await screen.queryByText('This is when you would like to be picked up')).toBeNull();
+    });
+
+    
+    test('drop off time description appears after hover delay', async () => {
+        render(<RideForm />);
+      
+        const dropOffTimeField = screen.getByTestId('RideForm-end');
+        fireEvent.mouseEnter(dropOffTimeField);
+      
+        expect(await screen.findByText('This is the latest you would like to arrive by')).toBeInTheDocument();
+
+        fireEvent.mouseLeave(dropOffTimeField);
+        expect(await screen.queryByText('This is the latest you would like to arrive by')).toBeNull();
     });
 
 });


### PR DESCRIPTION
hovering over the two fields show a short explanation of each, along the lines of "This is when you would like to picked up" and "This is the latest that you would like to arrive by"

*considered as optional part of issue #37 on our team's Kanban board, copied from issue #94 from the slack announcement link*

![hover_screenshot_1](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/77473114/dc757d2e-cd8d-4ee7-9f8c-b78f0a6a0de2)

![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/77473114/f692f7d2-6b92-49cc-9662-887a0c69a2fc)

Functionality:
-         When cursor is over pick up time form input box a description box should appear to the top right just above
-         Similarly for drop off time form input box

-          these should function independently if cursor is in one input box the hover effect should only display the description for that box, not both.


