### PR TITLE
Mw - rider application "show" page

### DIFF
--- a/frontend/src/stories/components/RiderApplication/RiderApplicationShowPageMember.stories.js
+++ b/frontend/src/stories/components/RiderApplication/RiderApplicationShowPageMember.stories.js
@@ -23,11 +23,22 @@ Default.parameters = {
             return res(ctx.json(systemInfoFixtures.showingNeither));
         }),
         rest.get('/api/riderApplication', (_req, res, ctx) => {
-            return res(ctx.json(riderApplicationFixtures.threeRiderApplications[0]));
+            return res(ctx.json([]));
+        })
+    ]
+}
+
+export const oneRiderApplication = Template.bind({});
+oneRiderApplication.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
         }),
-        // rest.get('/api/riderApplication/get', (req, res, ctx) => {
-        //     window.alert("GET: " + JSON.stringify(req.url));
-        //     return res(ctx.status(200),ctx.json({}));
-        // })
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/riderApplication', (_req, res, ctx) => {
+            return res(ctx.json(riderApplicationFixtures.oneRiderApplication[0]));
+        })
     ]
 }

--- a/frontend/src/stories/components/RiderApplication/RiderApplicationShowPageMember.stories.js
+++ b/frontend/src/stories/components/RiderApplication/RiderApplicationShowPageMember.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import RiderApplicationShowPage from 'main/pages/RiderApplication/RiderApplicationShowPageMember';
+import { riderApplicationFixtures } from 'fixtures/riderApplicationFixtures';
+
+export default {
+    title: 'pages/RiderApplication/RiderApplicationShowPageMember',
+    component: RiderApplicationShowPage
+};
+
+const Template = () => <RiderApplicationShowPage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/riderApplication', (_req, res, ctx) => {
+            return res(ctx.json(riderApplicationFixtures.threeRiderApplications[0]));
+        }),
+        // rest.get('/api/riderApplication/get', (req, res, ctx) => {
+        //     window.alert("GET: " + JSON.stringify(req.url));
+        //     return res(ctx.status(200),ctx.json({}));
+        // })
+    ]
+}


### PR DESCRIPTION
I created the "show" page, which only allows you to see all the fields but not edit them. To see that, go to the "apply to be a rider" in the navbar and click the blue show button on the table in the index page. 
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/97565489/526968bc-516e-4cfa-802f-977927ebd225)


Upon pressing that, you'll see the show page which only shows info and has a cancel button.
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/97565489/9d5f86a8-9fde-4469-bf0c-0f843dc62456)

Storybook screenshot:
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/97565489/19a92127-fd43-4bdd-b7cd-924734e8b7d2)
![image](https://github.com/ucsb-cs156-w24/proj-gauchoride-w24-7pm-2/assets/97565489/5b730c16-c813-4fa6-8a8d-e5ae1cfa6617)



QA Deployment:
https://gauchoride-michaelw1985-dev.dokku-14.cs.ucsb.edu/

Closes #29 